### PR TITLE
Feature - BGL02 - Setup raspberry and run BGL docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ The steps to run the application in docker are the following:
 ### Ensure you have a working Docker instance
 Ensure that Docker Desktop or similar are active.
 
+### Ensure you have a docker builder for multiplatforms
+If you don't have it, run the following command:
+```
+docker buildx create --name my-multiplatform-builder --driver docker-container --use
+docker buildx inspect my-multiplatform-builder --bootstrap
+```
+
 ### Ensure you have a docker network already up
 If you don't have it, run the following command:
 ```
 docker network create boogle-network
 ```
 
-### Create docker images
+### Create local docker images
 To create the docker images of the db and the application, go on the root of the project and run:
 ```
 mvn clean install -Plocal-image
@@ -42,7 +49,7 @@ If you only want to create only the application image, run the previous command 
 To run a docker db container, run the following command and populate the db variables as you need:
 
 ```
-docker run --name boogle-bugo-data-shell-db --network=boogle-network -e POSTGRES_DB=dbBds -e POSTGRES_USER=dbBds -e POSTGRES_PASSWORD=dbBds -dp 127.0.0.1:5434:5432 pyrosandro/boogle-bugo-data-shell-db-image:0.0.1-SNAPSHOT
+docker run --name boogle-bugo-data-shell-db --network=boogle-network -e POSTGRES_DB=dbBds -e POSTGRES_USER=dbBds -e POSTGRES_PASSWORD=dbBds -v C:\Users\PyroSandro\Desktop\PublicRepos\boogle\boogle-extra\bugo-data-shell-db-liquibase.properties:/config/liquibase.properties -dp 127.0.0.1:5434:5432 pyrosandro/boogle-bugo-data-shell-db-image:0.0.1-SNAPSHOT
 ```
 
 Command explanation:
@@ -52,22 +59,9 @@ Command explanation:
 4. **-e POSTGRES_DB=dbBds:** This option sets the environment variable POSTGRES_DB inside the container to "dbBds". This variable is used to specify the name of the PostgreSQL database to be created inside the container.
 5. **-e POSTGRES_USER=dbBds:** This option sets the environment variable POSTGRES_USER inside the container to "dbBds". This variable is used to specify the username for connecting to the PostgreSQL database.
 6. **-e POSTGRES_PASSWORD=dbBds:** This option sets the environment variable POSTGRES_PASSWORD inside the container to "dbBds". This variable is used to specify the password for connecting to the PostgreSQL database.
-7. **-dp 127.0.0.1:5434:5432:** This option specifies the port mapping for the container. It maps port 5432 on the container to port 5434 on the host machine (127.0.0.1). The -d flag tells Docker to run the container in detached mode (in the background), and the -p flag specifies the port mapping.
-8. **pyrosandro/boogle-bugo-data-shell-db-image:0.0.1-SNAPSHOT:** This is the name of the Docker image to use for creating the container. It specifies the image "pyrosandro/boogle-bugo-data-shell-db-image" with the tag "0.0.1-SNAPSHOT".
-
-### Install liquibase scripts
-
-Once the db is installed, you can run your liquibase scripts by going into liquibase folder and run the following command:
-
-```
-mvn install -Pliquibase
-```
-
-Note: if you need to rollback your scripts, run the following command (in the example, we rollback the last 2 scripts from master.xml):
-
-```
-mvn clean -Pliquibase -Dliquibase.rollbackCount=2
-```
+7. **-v C:\Users\PyroSandro\Desktop\PublicRepos\boogle\boogle-extra\bugo-data-shell-db-liquibase.properties:/config/liquibase.properties:** This mounts a file from the host machine (C:\Users\PyroSandro\Desktop\PublicRepos\boogle\boogle-extra\bugo-data-shell-db-liquibase.properties) to the container's file system (/config/liquibase.properties). This is useful for configuration files that need to be accessible to the application running in the container.
+8. **-dp 127.0.0.1:5434:5432:** This option specifies the port mapping for the container. It maps port 5432 on the container to port 5434 on the host machine (127.0.0.1). The -d flag tells Docker to run the container in detached mode (in the background), and the -p flag specifies the port mapping.
+9. **pyrosandro/boogle-bugo-data-shell-db-image:0.0.1-SNAPSHOT:** This is the name of the Docker image to use for creating the container. It specifies the image "pyrosandro/boogle-bugo-data-shell-db-image" with the tag "0.0.1-SNAPSHOT".
 
 ### Run app docker container
 
@@ -88,6 +82,8 @@ Command explanation:
 
 Note: The external-props.yml file should contain the values of the variables needed in application.yml file. For an example, you can see the file application-localdev.yml
 
+-----------------------------------------
+
 ## Deploy artifacts and docker images
 
 ### Deploy artifacts on github packages
@@ -96,7 +92,7 @@ To deploy artifacts on github packages, ensure that in pom.xml you have set up t
 <distributionManagement>
     <repository>
         <id>my-github-repos</id>
-        <name>GitHub alessandrogranato auth repo</name>
+        <name>GitHub alessandrogranato bugo-data-shell repo</name>
         <url>https://maven.pkg.github.com/alessandrogranato/bugo-data-shell</url>
     </repository>
 </distributionManagement>
@@ -108,14 +104,46 @@ To deploy the artifacts, simply run the following command:
 mvn clean deploy
 ```
 
-### Deploy docker images on dockerhub
+### Deploy artifacts and docker images all at once
 To deploy application and db docker images, go on parent pom folder and launch the following command:
 ```
-mvn clean deploy -Plocal-image -Pdeploy-docker-image
+mvn clean deploy -Pbuild-and-deploy-docker-image
 ```
-This command will create the docker images from packager and packager-db submodules using the profile local-image, then they will be deployed using the profile deploy-docker-image.
 
-### Deploy artifacts and docker images all at once
-Since with mvn clean deploy we push artifacts on github packages and adding -Plocal-image and -Pdeploy-doker-image we add profiles to create and push docker images on docker repos, we can simply go in parent folder (where there is parent pom.xml file) and launch the following command to upload everything together. (Yes, it's equal to the previous command)
+-----------------------------------------
+
+## Post installation operations
+
+### Dev environment - Install liquibase scripts
+
+Once the db is installed, you can run your liquibase scripts by going into the project liquibase folder and run the following command:
+
 ```
-mvn clean deploy -Plocal-image -Pdeploy-docker-image
+mvn install -Pliquibase
+```
+
+Note: if you need to rollback your scripts, run the following command (in the example, we rollback the last 2 scripts from master.xml):
+
+```
+mvn clean -Pliquibase -Dliquibase.rollbackCount=2
+```
+
+### Prod environment - Copy and run liquibase scripts
+
+In prod environment you don't have the bugo-data-shell project, but you have the container. If you need to add or remove scripts, you can manually copy the master.xml file and the sql folder inside the container, then run the liquibase command to update or rollback. In order to do so, you can do the following:
+**Note:** We assume your sql folder and master.xml file have been already put in host folder: C:\Users\PyroSandro\Desktop\PublicRepos\boogle\boogle-extra\bugo-data-shell-db-liquibase\sql
+
+```
+docker cp C:\Users\PyroSandro\Desktop\PublicRepos\boogle\boogle-extra\bugo-data-shell-db-liquibase\sql boogle-bugo-data-shell-db:/config
+docker cp C:\Users\PyroSandro\Desktop\PublicRepos\boogle\boogle-extra\bugo-data-shell-db-liquibase\master.xml boogle-bugo-data-shell-db:/config/master.xml
+```
+
+If you want to add scripts, run the following command:
+```
+docker exec boogle-bugo-data-shell-db bash -c "cd /config && liquibase --changelog-file=master.xml update"
+```
+
+If you want to rollback scripts (in the example only the last), run the following command:
+```
+docker exec boogle-bugo-data-shell-db bash -c "cd /config && liquibase --changelog-file=master.xml rollbackCount 1"
+```

--- a/packager-db/Dockerfile
+++ b/packager-db/Dockerfile
@@ -1,5 +1,47 @@
 # Use the official PostgreSQL 13.5 image from Docker Hub
 FROM postgres:13.5
 
+# Install dependencies for Liquibase
+RUN apt-get update && apt-get install -y \
+    openjdk-11-jdk \
+    wget \
+    unzip \
+    && apt-get clean
+
+# Set environment variables for Liquibase
+ENV LIQUIBASE_VERSION=4.6.1
+ENV LIQUIBASE_HOME=/opt/liquibase
+
+RUN mkdir -p ${LIQUIBASE_HOME}
+
+# Download and install Liquibase
+RUN wget https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz -O /tmp/liquibase.tar.gz && \
+    tar -xf /tmp/liquibase.tar.gz -C ${LIQUIBASE_HOME} && \
+    rm /tmp/liquibase.tar.gz && \
+    ln -s ${LIQUIBASE_HOME}/liquibase /usr/local/bin/liquibase
+
+# Add Liquibase to the PATH
+ENV PATH="${LIQUIBASE_HOME}:${PATH}"
+
+# Verify installation
+RUN ${LIQUIBASE_HOME}/liquibase --version
+
+# Set the working directory to /config
+WORKDIR /config
+
+# Copy configuration files
+COPY ./target/master.xml /config/master.xml
+COPY ./target/sql/ /config/sql/
+COPY ./initialize-db.sh /initialize-db.sh
+
+# Ensure the initialize-db.sh script is executable
+RUN chmod +x /initialize-db.sh
+
 # Expose the PostgreSQL port
 EXPOSE 5432
+
+# Set the entrypoint to run PostgreSQL
+ENTRYPOINT ["/initialize-db.sh"]
+
+#Command to run the initialize-db.sh script after PostgreSQL starts
+CMD ["postgres"]

--- a/packager-db/initialize-db.sh
+++ b/packager-db/initialize-db.sh
@@ -1,0 +1,21 @@
+#!/bin/sh -ex
+
+# Check if the liquibase.properties file exists
+if [ ! -e ./liquibase.properties ]; then
+  echo "Unable to read /config/liquibase.properties!"
+  exit 1
+fi
+
+/usr/local/bin/docker-entrypoint.sh postgres &
+
+# Wait for PostgreSQL to be ready
+until pg_isready -U $POSTGRES_USER -p 5432; do
+  echo 'Waiting for PostgreSQL to become available...'
+  sleep 5
+done
+
+# Run Liquibase update
+liquibase --changelog-file=master.xml update
+
+# Use tail to keep the container running
+tail -f /dev/null

--- a/packager-db/pom.xml
+++ b/packager-db/pom.xml
@@ -18,7 +18,52 @@
         <docker.repo.url>${docker.repo}</docker.repo.url>
         <docker.image.name>boogle-bugo-data-shell-db-image</docker.image.name>
         <resources.path>${project.basedir}</resources.path>
+        <resources.path.dependency.liquibase>${project.parent.basedir}/liquibase/src/main/resources</resources.path.dependency.liquibase>
     </properties>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven.resources.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>Dockerfile</include>
+                                        <include>initialize-db.sh</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>${resources.path.dependency.liquibase}/</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>master.xml</include>
+                                        <include>sql/</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>
@@ -159,7 +204,7 @@
         </profile>
 
         <profile>
-            <id>deploy-docker-image</id>
+            <id>build-and-deploy-docker-image</id>
             <build>
                 <plugins>
                     <plugin>
@@ -176,8 +221,14 @@
                                     <executable>docker</executable>
                                     <workingDirectory>${resources.path}</workingDirectory>
                                     <arguments>
-                                        <argument>push</argument>
+                                        <argument>buildx</argument>
+                                        <argument>build</argument>
+                                        <argument>--platform</argument>
+                                        <argument>linux/amd64,linux/arm64</argument>
+                                        <argument>-t</argument>
                                         <argument>${docker.repo.url}/${docker.image.name}:${project.version}</argument>
+                                        <argument>--push</argument>
+                                        <argument>.</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/packager/pom.xml
+++ b/packager/pom.xml
@@ -199,7 +199,7 @@
         </profile>
 
         <profile>
-            <id>deploy-docker-image</id>
+            <id>build-and-deploy-docker-image</id>
             <build>
                 <plugins>
                     <plugin>
@@ -216,8 +216,14 @@
                                     <executable>docker</executable>
                                     <workingDirectory>${resources.path}</workingDirectory>
                                     <arguments>
-                                        <argument>push</argument>
+                                        <argument>buildx</argument>
+                                        <argument>build</argument>
+                                        <argument>--platform</argument>
+                                        <argument>linux/amd64,linux/arm64</argument>
+                                        <argument>-t</argument>
                                         <argument>${docker.repo.url}/${docker.image.name}:${project.version}</argument>
+                                        <argument>--push</argument>
+                                        <argument>.</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<flatten.maven.plugin.version>1.1.0</flatten.maven.plugin.version>
 		<mapstruct.version>1.4.2.Final</mapstruct.version>
 		<spring-cloud.version>2021.0.7</spring-cloud.version>
+		<maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
- change Dockerfile in packager-db downloading now liquibase and passing to image sql and master file that will be run at installation time
- add initialize-db.sh which runs liquibase initial scripts on db at installation time
- in parent pom, add maven resources plugin version property
- in packager and packager-db pom, rename maven profile deploy-docker-image in build-and-deploy-docker-image
- in packager and packager-db pom, add buildx for multiplatform deploy, with arguments linux/amd64,linux/arm64
- in packager-db pom, add liquibase resource folder as property; add maven-resources-plugin to copy Dockerfile and initialize-db.sh from liquibase folder
- add info about how to create docker multiplatform builder in README.md
- change instructions to run boogle-bugo-data-shell-db in README.md
- add instructions to add/remove future liquibase changesets post installation